### PR TITLE
Rq exporter http

### DIFF
--- a/prometheus.yml
+++ b/prometheus.yml
@@ -129,7 +129,7 @@ scrape_configs:
       - targets: ['${data_hub_api_redis_queue_exporter_uat}']
 
   - job_name: 'data-hub-api-redis-queue-exporter'
-    scheme: 'https'
+    scheme: 'http'
     static_configs:
       - targets: ['${data_hub_api_redis_queue_exporter}']
 

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -124,7 +124,7 @@ scrape_configs:
       - targets: ['${data_hub_api_redis_queue_exporter_staging}']
 
   - job_name: 'data-hub-api-redis-queue-exporter-uat'
-    scheme: 'https'
+    scheme: 'http'
     static_configs:
       - targets: ['${data_hub_api_redis_queue_exporter_uat}']
 

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -114,12 +114,12 @@ scrape_configs:
       - targets: ['${data_workspace_exporter_dev_url}']
 
   - job_name: 'data-hub-api-redis-queue-exporter-dev'
-    scheme: 'https'
+    scheme: 'http'
     static_configs:
       - targets: ['${data_hub_api_redis_queue_exporter_dev}']
 
   - job_name: 'data-hub-api-redis-queue-exporter-staging'
-    scheme: 'https'
+    scheme: 'http'
     static_configs:
       - targets: ['${data_hub_api_redis_queue_exporter_staging}']
 


### PR DESCRIPTION
Applies the following change:
- Updates the 'scheme' in `data-hub-api-redis-queue-exporter....` jobs to http
